### PR TITLE
Fix Method Signature remapping for Array types

### DIFF
--- a/src/main/java/net/techcable/srglib/MethodSignature.java
+++ b/src/main/java/net/techcable/srglib/MethodSignature.java
@@ -33,8 +33,8 @@ public final class MethodSignature {
     }
 
     public MethodSignature mapTypes(UnaryOperator<JavaType> transformer) {
-        JavaType newReturnType = transformer.apply(returnType);
-        List<JavaType> newParameterTypes = this.parameterTypes.stream().map(transformer).collect(Collectors.toList());
+        JavaType newReturnType = returnType.mapClass(transformer);
+        List<JavaType> newParameterTypes = this.parameterTypes.stream().map(type -> type.mapClass(transformer)).collect(Collectors.toList());
         MethodSignature result = create(newParameterTypes, newReturnType);
         if (result.equals(this)) {
             return this;


### PR DESCRIPTION
`ArrayType` will map the inner class if you call `ArrayType.mapClass` with the transformer.

This is a port of https://github.com/phase/SrgLib/commit/c256ccf3bab11a3ad87e4f5d474fc743928227de